### PR TITLE
Update config.yml

### DIFF
--- a/MusterCull/config.yml
+++ b/MusterCull/config.yml
@@ -151,7 +151,7 @@ limits:
   culling: DAMAGE
   limit: 10
   range: 5
-  type: PIGZOMBIE
+- type: PIGZOMBIE
   culling: SPAWNER
   limit: 20
   range: 30


### PR DESCRIPTION
Typo prevented it from loading the damage limit for zombie pigman which is why you had to cull them manually today.