### PR TITLE
Update EntityListener.java

### DIFF
--- a/MusterCull/src/com/untamedears/mustercull/EntityListener.java
+++ b/MusterCull/src/com/untamedears/mustercull/EntityListener.java
@@ -55,7 +55,7 @@ public class EntityListener extends Listener {
 		}
 		
 		if (!this.getPluginInstance().isPaused(CullType.SPAWN)) {
-			if (event.getSpawnReason() != SpawnReason.SPAWNER) {
+			if (event.getSpawnReason() != SpawnReason.SPAWNER || event.getSpawnReason() == SpawnReason.NATURAL) {
 				limit = this.getPluginInstance().getLimit(entity.getType(), CullType.SPAWN);
 				
 				if (limit != null) {


### PR DESCRIPTION
This should allow mustercull to keep mobs from naturally spawning above the limits set in the config.