### PR TITLE
Limit Armor Stand spawn within a sensible radius to prevent abuse.

### DIFF
--- a/MusterCull/plugin.yml
+++ b/MusterCull/plugin.yml
@@ -2,9 +2,9 @@
 # MusterCull
 # Bukkit plug-in connector file.
 #
-name: MusterCull
+name: ${project.name}
 main: com.untamedears.mustercull.MusterCull
-version: 1.4.3
+version: ${project.version}
 description: Removes persistent mobs due to overcrowding and other purposes.
 author: Celdecea
 commands:

--- a/MusterCull/src/com/untamedears/mustercull/MusterCull.java
+++ b/MusterCull/src/com/untamedears/mustercull/MusterCull.java
@@ -341,7 +341,6 @@ public class MusterCull extends JavaPlugin {
         	List<Entity> entitiesInWorld = new ArrayList<Entity>(world.getEntitiesByClasses(classes));
             for (Entity entity : entitiesInWorld) {
                 if (   (! (entity instanceof Player))
-                	   && (! (entity instanceof ArmorStand))
                 	   && (! entity.isDead())) {
                     entities.add(entity);
                 }
@@ -364,7 +363,6 @@ public class MusterCull extends JavaPlugin {
         
         for (Entity entity : entitiesInWorld) {
             if (   (! (entity instanceof Player))
-            	   && (! (entity instanceof ArmorStand))
             	   && (! entity.isDead())) {
                 entities.add(entity);
             }

--- a/config.yml
+++ b/config.yml
@@ -243,6 +243,10 @@ limits:
   spawnDelay: 3
   multiplier: 1
   multiplierLimit: 10
+- type: ARMOR_STAND
+  culling: SPAWN
+  limit: 5
+  range: 15
 
 # The amount of damage to apply to mobs which are considered crowded under the
 # DAMAGE method of culling.

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
           <include>**/*.java</include>
           <include>*.yml</include>
         </includes>
+		<filtering>true</filtering>
       </resource>
     </resources>
   </build>
@@ -34,8 +35,8 @@
   <dependencies>
     <dependency>
       <groupId>org.spigotmc</groupId>
-      <artifactId>Spigot1.8.3</artifactId>
-      <version>1.8.3</version>
+      <artifactId>Spigot1.8.7</artifactId>
+      <version>1.8.7</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Reverts pull 30 for issue #28, in addition to clarifying support for entity culling for entities that aren't Creatures (like Armor Stands). Config updated with an arbitrary limitation on stands. Existing placed stands aren't impacted. If a stand placement is cancelled, the stand is lost.